### PR TITLE
Added .nojekyll generation to documentation build script

### DIFF
--- a/tools/Build_Documentation_HTML.bat
+++ b/tools/Build_Documentation_HTML.bat
@@ -2,8 +2,9 @@
 echo cleaning old output...
 rmdir /s /q "../docs"
 echo running doxygen...
-@CALL doxygen Doxyfile > NUL
-@cd "../docs"
+CALL doxygen Doxyfile > NUL
+cd "../docs"
+type NUL > .nojekyll
 echo opening html...
-@START "" "index.html"
+START "" "index.html"
 PAUSE


### PR DESCRIPTION
The (previous) documentation build script wiped the entire /docs directory... which removed the .nojekyll file!

To fix this, just had to have the script add an (empty) .nojekyll file at some point. Easy fix!

Also took the opportunity to "clean up" the documentation building script.